### PR TITLE
OCCI/CORE/CREATE/001: if kind location is an url, do not prepend serv…

### DIFF
--- a/pOCCI/CORE.py
+++ b/pOCCI/CORE.py
@@ -348,7 +348,11 @@ class CORE_CREATE001(Test):
             ]
         )
 
-        body, response_headers, http_status, content_type = connection.post(url=occi_config['url'] + kind['location'], headers=['Content-Type: %s' % occi_config['mimetype']] + new_cat_h, body=new_cat_s)
+        if kind['location'].startswith("/"):
+            url = occi_config['url'] + kind['location']
+        else:
+            url = kind['location']
+        body, response_headers, http_status, content_type = connection.post(url=url, headers=['Content-Type: %s' % occi_config['mimetype']] + new_cat_h, body=new_cat_s)
         Test.clear_categories()
         check_create, tmp_err_msg = check_http_status("201 Created", http_status)
         err_msg += tmp_err_msg


### PR DESCRIPTION
…er url
Query interface may (should ?) return full url for categories locations
