### PR TITLE
Fix architecture attribute value

### DIFF
--- a/pOCCI/CORE.py
+++ b/pOCCI/CORE.py
@@ -348,7 +348,11 @@ class CORE_CREATE001(Test):
             ]
         )
 
-        body, response_headers, http_status, content_type = connection.post(url=occi_config['url'] + kind['location'], headers=['Content-Type: %s' % occi_config['mimetype']] + new_cat_h, body=new_cat_s)
+        if kind['location'].startswith("/"):
+            url = occi_config['url'] + kind['location']
+        else:
+            url = kind['location']
+        body, response_headers, http_status, content_type = connection.post(url=url, headers=['Content-Type: %s' % occi_config['mimetype']] + new_cat_h, body=new_cat_s)
         Test.clear_categories()
         check_create, tmp_err_msg = check_http_status("201 Created", http_status)
         err_msg += tmp_err_msg

--- a/pOCCI/CORE.py
+++ b/pOCCI/CORE.py
@@ -343,7 +343,7 @@ class CORE_CREATE001(Test):
                 }),
                 occi.Attribute({
                     'name': 'occi.compute.architecture',
-                    'value': 'arch',
+                    'value': 'x86',
                 }),
             ]
         )


### PR DESCRIPTION
architecture="arch" is not a valid value for a compute resource (must be x86 or x64)
